### PR TITLE
docs: fix example, debug is not an argument anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ api.close()
 from pymitsubishi import CapabilityDetector
 
 detector = CapabilityDetector(api=api)
-capabilities = detector.detect_all_capabilities(debug=True)
+capabilities = detector.detect_all_capabilities()
 
 # Check specific capabilities
 if capabilities.has_capability(CapabilityType.OUTDOOR_TEMPERATURE_SENSOR):

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ api.close()
 ### Capability Detection
 
 ```python
-from pymitsubishi import CapabilityDetector
+from pymitsubishi import CapabilityDetector, CapabilityType
 
 detector = CapabilityDetector(api=api)
 capabilities = detector.detect_all_capabilities()

--- a/pymitsubishi/mitsubishi_parser.py
+++ b/pymitsubishi/mitsubishi_parser.py
@@ -612,7 +612,7 @@ class ErrorStates:
         try:
             code_head = payload[18:20]
             code_tail = payload[20:22]
-            is_abnormal_state = not (code_head == "80" and code_tail == "00")
+            is_abnormal_state = not (code_head in ("00", "80") and code_tail == "00")
             error_code = f"{code_head}{code_tail}"
 
             return ErrorStates(


### PR DESCRIPTION
Fix this traceback:

----> 2 capabilities = detector.detect_all_capabilities(debug=True) TypeError: CapabilityDetector.detect_all_capabilities() got an unexpected keyword argument 'debug'