### PR TITLE
Add tests for parsing

### DIFF
--- a/pymitsubishi/mitsubishi_parser.py
+++ b/pymitsubishi/mitsubishi_parser.py
@@ -168,6 +168,7 @@ class GeneralStates:
         - Wide vane adjustment flag detection
         - i-See sensor detection from mode byte
         """
+        logger.debug(f"Parsing general states payload: {payload}")
         if len(payload) < 42:
             return None
 
@@ -459,6 +460,7 @@ class SensorStates:
     @classmethod
     def parse_sensor_states(cls, payload: str) -> SensorStates | None:
         """Parse sensor states from hex payload"""
+        logger.debug(f"Parsing sensor states payload: {payload}")
         if len(payload) < 42:
             return None
 
@@ -507,6 +509,7 @@ class EnergyStates:
             payload: Hex payload string
             general_states: Optional general states for power estimation context
         """
+        logger.debug(f"Parsing energy states payload: {payload}")
         if len(payload) < 24:  # Need at least enough bytes for data[4]
             return None
 
@@ -606,6 +609,7 @@ class ErrorStates:
     @classmethod
     def parse_error_states(cls, payload: str) -> ErrorStates | None:
         """Parse error states from hex payload"""
+        logger.debug(f"Parsing error states payload: {payload}")
         if len(payload) < 22:
             return None
 
@@ -661,6 +665,8 @@ class ParsedDeviceState:
             elif EnergyStates.is_energy_states_payload(hex_lower):
                 # Parse energy states with context from general states if available
                 parsed_state.energy = EnergyStates.parse_energy_states(hex_lower, parsed_state.general)
+            else:
+                logger.debug(f"Ignoring unknown code value: {hex_value}")
 
         return parsed_state
 

--- a/tests/test_energy_states.py
+++ b/tests/test_energy_states.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pymitsubishi import EnergyStates
+
+
+@pytest.mark.parametrize(
+    "data_hex, operating",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc6201301006000000000001004100004200000000d3", False),  # all units off
+        ("fc6201301006000000000001004100004200000000d3", False),  # this indoor unit off, other on
+        ("fc62013010060000000102b951e50000420000000023", True),  # only this indoor unit on, others off
+        ("fc6201301006000000010014004100004200000000bf", True),  # all indoor units on
+        ("fc620130100600000000073851ec0000420000000099", True),  # all indoor units on
+        ("fc62013010060000000106e451ed00004200000000ec", True),  # all indoor units on
+    ],
+)
+def test_operating(data_hex, operating):
+    state = EnergyStates.parse_energy_states(data_hex)
+    assert state.operating == operating
+
+
+@pytest.mark.parametrize(
+    "data_hex, freq",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc6201301006000000000001004100004200000000d3", 0),  # all units off
+        ("fc6201301006000000000001004100004200000000d3", 0),  # this indoor unit off, other on
+        ("fc62013010060000000102b951e50000420000000023", 1),  # this indoor unit on, ~700W electrical consumption
+        ("fc6201301006000000010014004100004200000000bf", 2),  # all indoor units on, ~1.9kW electrical consumption
+        ("fc620130100600000000073851ec0000420000000099", 2),  # all indoor units on, ~1.8kW electrical consumption
+    ],
+)
+def test_compressor_frequency(data_hex, freq):
+    state = EnergyStates.parse_energy_states(data_hex)
+    assert state.compressor_frequency == freq

--- a/tests/test_error_states.py
+++ b/tests/test_error_states.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pymitsubishi import ErrorStates
+
+
+@pytest.mark.parametrize(
+    "data_hex",
+    [
+        "fc6201301004000000800000000000000000000000d9",
+    ],
+)
+def test_error_states(data_hex):
+    state = ErrorStates.parse_error_states(data_hex)
+    assert state.error_code == format(0x8000, "04x")
+    assert not state.is_abnormal_state

--- a/tests/test_general_states.py
+++ b/tests/test_general_states.py
@@ -1,0 +1,116 @@
+import pytest
+
+from pymitsubishi import DriveMode, GeneralStates, HorizontalWindDirection, PowerOnOff, VerticalWindDirection
+
+
+@pytest.mark.parametrize(
+    "data_hex, power, mode",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc62013010020000000b070000000083b046000000d0", PowerOnOff.OFF, DriveMode.COOLER),
+        ("fc62013010020000010b070000000083b046000000cf", PowerOnOff.ON, DriveMode.COOLER),
+        ("fc62013010020000010a070000000083b032000000e4", PowerOnOff.ON, DriveMode.DEHUM),
+        ("fc620130100200000109090000000083ac28000000f1", PowerOnOff.ON, DriveMode.HEATER),
+        ("fc620130100200000107070000000083b028000000f1", PowerOnOff.ON, DriveMode.FAN),
+        ("fc620130100200000108080000000083ae46000000d3", PowerOnOff.ON, DriveMode.AUTO),
+        ("fc6201301002000001080b0000000083a846000000d6", PowerOnOff.ON, DriveMode.AUTO),  # auto, 20º => cooling
+        ("fc620130100200000108010000000083bc46000000cc", PowerOnOff.ON, DriveMode.AUTO),  # auto, 30º => heating
+    ],
+)
+def test_parse_general_states_mode(data_hex, power, mode):
+    states = GeneralStates.parse_general_states(data_hex)
+    assert states.power_on_off == power
+    assert states.drive_mode == mode
+
+
+@pytest.mark.parametrize(
+    "data_hex, temp",
+    [
+        ("fc62013010020000010b070000000083b046000000cf", 24.0),
+        ("fc62013010020000010b090000000083ac46000000d1", 22.0),
+    ],
+)
+def test_parse_general_states_temp(data_hex, temp):
+    states = GeneralStates.parse_general_states(data_hex)
+    assert states.temperature == temp * 10
+
+
+@pytest.mark.parametrize(
+    "data_hex, wind_speed",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc62013010020000010b070000000083b046000000cf", 0),  # auto
+        ("fc62013010020000010b070100000083b046000000ce", 1),  # "silent"
+        ("fc620130100200000107070200000083b028000000ef", 2),  # 1 bar
+        ("fc620130100200000107070300000083b028000000ee", 3),  # 2 bars
+        # no 4 from my remote
+        ("fc620130100200000107070500000083b028000000ec", 5),  # 3 bars
+        ("fc620130100200000107070600000083b028000000eb", 6),  # 4 bars, max
+    ],
+)
+def test_parse_general_states_wind_speed(data_hex, wind_speed):
+    states = GeneralStates.parse_general_states(data_hex)
+    assert states.wind_speed.value == wind_speed
+
+
+@pytest.mark.parametrize(
+    "data_hex, v_vane_l, v_vane_r",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc62013010020000010b070000000083b046000000cf", VerticalWindDirection.AUTO, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070001000083b046000000ce", VerticalWindDirection.V1, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070002000083b046000000cd", VerticalWindDirection.V2, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070003000083b046000000cc", VerticalWindDirection.V3, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070004000083b046000000cb", VerticalWindDirection.V4, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070005000083b046000000ca", VerticalWindDirection.V5, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070007000083b046000000c8", VerticalWindDirection.SWING, VerticalWindDirection.AUTO),
+        ("fc62013010020000010b070001000083b046000000ce", VerticalWindDirection.AUTO, VerticalWindDirection.V1),
+        ("fc62013010020000010b070002000083b046000000cd", VerticalWindDirection.AUTO, VerticalWindDirection.V2),
+        ("fc62013010020000010b070005000083b046000000ca", VerticalWindDirection.AUTO, VerticalWindDirection.V5),
+        ("fc62013010020000010b070007000083b046000000c8", VerticalWindDirection.AUTO, VerticalWindDirection.SWING),
+        ("fc62013010020000010b070005000083b046000000ca", VerticalWindDirection.V1, VerticalWindDirection.V5),
+        ("fc62013010020000010b070005000083b046000000ca", VerticalWindDirection.V5, VerticalWindDirection.V1),
+    ],
+)
+def test_parse_general_states_vertical_vane(data_hex, v_vane_l: VerticalWindDirection, v_vane_r: VerticalWindDirection):
+    states = GeneralStates.parse_general_states(data_hex)
+
+    # My system has a left & right vertical vane, but I can't find the bits to see them separately
+    # The "right" vane bits seem to report the "highest" one
+    # The "left" vane stays "auto"
+    v_vane = VerticalWindDirection(max(v_vane_l.value, v_vane_r.value))
+    assert states.vertical_wind_direction_right == v_vane
+    assert states.vertical_wind_direction_left == VerticalWindDirection.AUTO
+
+    # Expected behaviour, currently fails:
+    assert states.vertical_wind_direction_left == v_vane_l
+    assert states.vertical_wind_direction_right == v_vane_r
+
+
+@pytest.mark.parametrize(
+    "data_hex, vane",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc62013010020000010b070000000081b046000000d1", HorizontalWindDirection.L),
+        ("fc62013010020000010b070000000082b046000000d0", HorizontalWindDirection.LS),
+        ("fc62013010020000010b070000000083b046000000cf", HorizontalWindDirection.C),
+        ("fc62013010020000010b070000000084b046000000ce", HorizontalWindDirection.RS),
+        ("fc62013010020000010b070000000085b046000000cd", HorizontalWindDirection.R),
+        ("fc62013010020000010b070000000088b046000000ca", HorizontalWindDirection.LR),  # split
+        ("fc62013010020000010b07000000008cb046000000c6", HorizontalWindDirection.LCR_S),  # sweep
+    ],
+)
+def test_parse_general_states_horizontal_vane(data_hex, vane):
+    states = GeneralStates.parse_general_states(data_hex)
+    assert states.horizontal_wind_direction == vane
+
+
+@pytest.mark.parametrize(
+    "data_hex, h_vane, isee_h_vane",
+    [  #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        ("fc62013010020000010b070000000083b046000000cf", HorizontalWindDirection.C, 0),  # off
+        ("fc62013010020000010b070000000080b046000100d1", HorizontalWindDirection.AUTO, 1),  # avoid person
+        ("fc62013010020000010b070000000080b046000200d0", HorizontalWindDirection.AUTO, 2),  # aim at person
+        ("fc62013010020000010b070000000080b046000000d2", HorizontalWindDirection.AUTO, 0),  # wide
+    ],
+)
+def test_parse_general_states_h_vane_isee(data_hex, h_vane, isee_h_vane):
+    states = GeneralStates.parse_general_states(data_hex)
+    assert states.horizontal_wind_direction == h_vane
+    assert states.wind_and_wind_break_direct == isee_h_vane

--- a/tests/test_sensor_states.py
+++ b/tests/test_sensor_states.py
@@ -1,0 +1,27 @@
+import pytest
+
+from pymitsubishi import SensorStates
+
+
+@pytest.mark.parametrize(
+    "data_hex, room_temperature",
+    [
+        ("fc620130100300000e00c0b0affe42000114a7000031", 23.5),
+        ("fc620130100300000b00baabaafe4200009a33000033", 21.0),
+    ],
+)
+def test_room_temperature(data_hex, room_temperature):
+    state = SensorStates.parse_sensor_states(data_hex)
+    assert state.room_temperature == room_temperature * 10
+
+
+@pytest.mark.parametrize(
+    "data_hex, outside_temperature",
+    [
+        ("fc620130100300000e00c0b0affe42000114a7000031", 32.0),
+        ("fc620130100300000b00baabaafe4200009a33000033", 29.0),
+    ],
+)
+def test_outside_temperature(data_hex, outside_temperature):
+    state = SensorStates.parse_sensor_states(data_hex)
+    assert state.outside_temperature == outside_temperature * 10


### PR DESCRIPTION
I've added a bunch of code_value's that I observed on my setup.

For some properties, there is a mismatch between my expectations and the current implementation:

* GeneralStates, Vertical Vane: I don't see any bits to indicate the left and right vertical vane separately. If anyone has this working, please provide some examples. Otherwise I'm inclined to remove the left/right split and use only a single vertical vane property.

* EnergyStates, Compressor Frequency: I've only observed `0` and `1`, but nothing else. If anyone has seen different values, please provide some examples. Otherwise I think this field is not labeled correctly as being the compressor *frequency*. Consequently, at least on my setup, the energy calculation is wrong.

* EnergyStates, Operating: I think I've captured an instance where the heat pump was ON, but the current "operating" field was False. So I'm not sure if this field is identified correctly, but I'm may have done a bad copy-paste as well. Will follow up on this.

Currently these tests fail, so we'll need to change the implementation to make them succeed.