### PR TITLE
feat: Remote temperature, 0x07

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ htmlcov/
 .venv/
 venv*/
 ENV*/
+Pipfile
+Pipfile.lock

--- a/pymitsubishi/__init__.py
+++ b/pymitsubishi/__init__.py
@@ -20,11 +20,11 @@ from .mitsubishi_parser import (
     ParsedDeviceState,
     PowerOnOff,
     RemoteLock,
+    RemoteTemperatureMode,
+    RemoteTemperatureStates,
     SensorStates,
     VerticalWindDirection,
     WindSpeed,
-    RemoteTemperatureStates,
-    RemoteTemperatureMode
 )
 
 __all__ = [
@@ -44,4 +44,6 @@ __all__ = [
     "ErrorStates",
     "ParsedDeviceState",
     "RemoteLock",
+    "RemoteTemperatureMode",
+    "RemoteTemperatureStates",
 ]

--- a/pymitsubishi/__init__.py
+++ b/pymitsubishi/__init__.py
@@ -23,6 +23,8 @@ from .mitsubishi_parser import (
     SensorStates,
     VerticalWindDirection,
     WindSpeed,
+    RemoteTemperatureStates,
+    RemoteTemperatureMode
 )
 
 __all__ = [

--- a/pymitsubishi/mitsubishi_controller.py
+++ b/pymitsubishi/mitsubishi_controller.py
@@ -46,10 +46,8 @@ class MitsubishiChangeSet:
         self.changes |= Controls.PowerOnOff
 
     def set_mode(self, drive_mode: DriveMode):
-        if drive_mode == DriveMode.AUTO:
-            drive_mode = 8
-        else:
-            drive_mode = drive_mode.value
+        drive_mode = DriveMode._AUTO if drive_mode == DriveMode.AUTO else drive_mode.value
+
         self.desired_state.drive_mode = drive_mode
         self.changes |= Controls.DriveMode
 
@@ -136,7 +134,9 @@ class MitsubishiController:
 
     def changeset(self):
         self._ensure_state_available()
-        return MitsubishiChangeSet(self.state.general)
+        if self.state and self.state.general:
+            return MitsubishiChangeSet(self.state.general)
+        raise TypeError("self.state.general can not be None")
 
     def apply_changeset(self, cs: MitsubishiChangeSet) -> ParsedDeviceState | None:
         new_state = None
@@ -175,47 +175,47 @@ class MitsubishiController:
             remote_lock=overrides.get("remote_lock", self.state.general.remote_lock),
         )
 
-    def set_power(self, power_on: bool) -> ParsedDeviceState:
+    def set_power(self, power_on: bool) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_power(PowerOnOff.ON if power_on else PowerOnOff.OFF)
         return self.apply_changeset(cs)
 
-    def set_temperature(self, temperature_celsius: float) -> ParsedDeviceState:
+    def set_temperature(self, temperature_celsius: float) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_temperature(temperature_celsius)
         return self.apply_changeset(cs)
 
-    def set_mode(self, mode: DriveMode) -> ParsedDeviceState:
+    def set_mode(self, mode: DriveMode) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_mode(mode)
         return self.apply_changeset(cs)
 
-    def set_fan_speed(self, speed: WindSpeed) -> ParsedDeviceState:
+    def set_fan_speed(self, speed: WindSpeed) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_fan_speed(speed)
         return self.apply_changeset(cs)
 
-    def set_vertical_vane(self, direction: VerticalWindDirection) -> ParsedDeviceState:
+    def set_vertical_vane(self, direction: VerticalWindDirection) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_vertical_vane(direction)
         return self.apply_changeset(cs)
 
-    def set_horizontal_vane(self, direction: HorizontalWindDirection) -> ParsedDeviceState:
+    def set_horizontal_vane(self, direction: HorizontalWindDirection) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_horizontal_vane(direction)
         return self.apply_changeset(cs)
 
-    def set_dehumidifier(self, setting: int) -> ParsedDeviceState:
+    def set_dehumidifier(self, setting: int) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_dehumidifier(setting)
         return self.apply_changeset(cs)
 
-    def set_power_saving(self, enabled: bool) -> ParsedDeviceState:
+    def set_power_saving(self, enabled: bool) -> ParsedDeviceState | None:
         cs = self.changeset()
         cs.set_power_saving(enabled)
         return self.apply_changeset(cs)
 
-    def send_buzzer_command(self, enabled: bool = True) -> ParsedDeviceState:
+    def send_buzzer_command(self, enabled: bool = True) -> ParsedDeviceState | None:
         """Send buzzer control command"""
         self._ensure_state_available()
         if self.state is not None and self.state.general is not None:

--- a/pymitsubishi/mitsubishi_parser.py
+++ b/pymitsubishi/mitsubishi_parser.py
@@ -26,6 +26,7 @@ class DriveMode(enum.Enum):
     DEHUM = 2
     COOLER = 3
     FAN = 7
+    _AUTO = 8
 
 
 class WindSpeed(enum.Enum):
@@ -699,9 +700,10 @@ def legacy_to_celsius(data: bytes) -> float:
     if len(data) != 1:
         raise ValueError("Legacy temperature out of byte range")
     temp = (31 - int.from_bytes(data, "big")) % 0x10
+    temp_float = float(temp)
     if (int.from_bytes(data, "big") // 0x10) > 0:
-        temp += 0.5
-    return temp + 16
+        temp_float += 0.5
+    return temp_float + 16
 
 
 def celsius_to_legacy(temp: float) -> bytes:

--- a/pymitsubishi/mitsubishi_parser.py
+++ b/pymitsubishi/mitsubishi_parser.py
@@ -682,7 +682,7 @@ def convert_temperature_to_segment(temperature: int) -> str:
 
 def celsius_to_enhanced_temperature(temperature: float) -> bytes:
     """Convert temperature (Celsius) to enhanced temperature, ref https://muart-group.github.io/developer/it-protocol/data-types/temperature-units#enhanced-temperatures"""
-    value = int((temperature * 2) + 128)
+    value = round((temperature * 2) + 128)
     if not 0 <= value <= 255:
         raise ValueError("Enhanced temperature out of byte range")
     return value.to_bytes(1, "big")

--- a/pymitsubishi/mitsubishi_parser.py
+++ b/pymitsubishi/mitsubishi_parser.py
@@ -597,8 +597,8 @@ class RemoteTemperatureStates:
             data[1] in [0x62, 0x7B] and data[5] == 0x07
         )  # <- Doesn't exist? How to know if we're using an external thermostat?
 
-    @classmethod
-    def generate_remote_temperature_command(self, mode: RemoteTemperatureMode, temperature_celsius: float) -> bytes:
+    @staticmethod
+    def generate_remote_temperature_command(mode: RemoteTemperatureMode, temperature_celsius: float) -> bytes:
         payload = bytearray(
             [mode, *celsius_to_legacy(temperature_celsius), *celsius_to_enhanced_temperature(temperature_celsius)]
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,6 +16,10 @@ from pymitsubishi.mitsubishi_parser import (
     convert_temperature,
     convert_temperature_to_segment,
     get_normalized_temperature,
+    legacy_to_celsius,
+    celsius_to_legacy,
+    enhanced_temperature_to_celsius,
+    celsius_to_enhanced_temperature
 )
 
 from .test_fixtures import SAMPLE_CODE_VALUES, SAMPLE_PROFILE_CODES
@@ -67,6 +71,22 @@ class TestTemperatureConversion:
             if hex_val >= 0x80:  # Valid range
                 normalized = get_normalized_temperature(hex_val)
                 assert 0 <= normalized <= 400  # Valid normalized range
+        
+        real_temps = [12, 16, 18, 20, 22, 24, 26, 28, 27.5, 30, 31.5, 35]
+        for temp_units in real_temps:
+            # Test segment conversion
+            legacy = celsius_to_legacy(temp_units)
+            assert len(legacy) == 1
+
+            # Test segment format conversion
+            enhanced = celsius_to_enhanced_temperature(temp_units)
+            assert len(enhanced) == 1
+
+            legacy_normalized = legacy_to_celsius(legacy)
+            assert legacy_normalized == min(31.5,max(16,temp_units)) # min 16, max 31.5
+
+            enhanced_normalized = enhanced_temperature_to_celsius(enhanced)
+            assert enhanced_normalized == temp_units
 
     def test_temperature_edge_cases(self):
         """Test temperature conversion edge cases."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,13 +13,13 @@ from pymitsubishi.mitsubishi_parser import (
     GeneralStates,
     ParsedDeviceState,
     calc_fcc,
+    celsius_to_enhanced_temperature,
+    celsius_to_legacy,
     convert_temperature,
     convert_temperature_to_segment,
+    enhanced_temperature_to_celsius,
     get_normalized_temperature,
     legacy_to_celsius,
-    celsius_to_legacy,
-    enhanced_temperature_to_celsius,
-    celsius_to_enhanced_temperature
 )
 
 from .test_fixtures import SAMPLE_CODE_VALUES, SAMPLE_PROFILE_CODES
@@ -71,7 +71,7 @@ class TestTemperatureConversion:
             if hex_val >= 0x80:  # Valid range
                 normalized = get_normalized_temperature(hex_val)
                 assert 0 <= normalized <= 400  # Valid normalized range
-        
+
         real_temps = [12, 16, 18, 20, 22, 24, 26, 28, 27.5, 30, 31.5, 35]
         for temp_units in real_temps:
             # Test segment conversion
@@ -83,7 +83,7 @@ class TestTemperatureConversion:
             assert len(enhanced) == 1
 
             legacy_normalized = legacy_to_celsius(legacy)
-            assert legacy_normalized == min(31.5,max(16,temp_units)) # min 16, max 31.5
+            assert legacy_normalized == min(31.5, max(16, temp_units))  # min 16, max 31.5
 
             enhanced_normalized = enhanced_temperature_to_celsius(enhanced)
             assert enhanced_normalized == temp_units

--- a/tests/test_remote_temperature_states.py
+++ b/tests/test_remote_temperature_states.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pymitsubishi import RemoteTemperatureStates, RemoteTemperatureMode
+
+
+# These commands are not gathered from real thermostats. These were generated, but are working on at least MSZ-LN35VG2V produced date 2023.03
+@pytest.mark.parametrize(
+    "data_hex, mode, temperature",
+    [
+        ("fc4101301007000f81000000000000000000000000e7",RemoteTemperatureMode.UseInternal, 0.5),
+        ("fc4101301007000aaa000000000000000000000000c3",RemoteTemperatureMode.UseInternal, 21),
+        ("fc41013010070104b6000000000000000000000000bc",RemoteTemperatureMode.RemoteTemp, 27),
+        ("fc41013010070110c70000000000000000000000009f",RemoteTemperatureMode.RemoteTemp, 35.5),
+    ],
+)
+
+def test_remote_temperature_states(data_hex, mode, temperature):
+    command = RemoteTemperatureStates.generate_remote_temperature_command(mode, temperature)
+    assert command.hex() == data_hex

--- a/tests/test_remote_temperature_states.py
+++ b/tests/test_remote_temperature_states.py
@@ -1,19 +1,18 @@
 import pytest
 
-from pymitsubishi import RemoteTemperatureStates, RemoteTemperatureMode
+from pymitsubishi import RemoteTemperatureMode, RemoteTemperatureStates
 
 
 # These commands are not gathered from real thermostats. These were generated, but are working on at least MSZ-LN35VG2V produced date 2023.03
 @pytest.mark.parametrize(
     "data_hex, mode, temperature",
     [
-        ("fc4101301007000f81000000000000000000000000e7",RemoteTemperatureMode.UseInternal, 0.5),
-        ("fc4101301007000aaa000000000000000000000000c3",RemoteTemperatureMode.UseInternal, 21),
-        ("fc41013010070104b6000000000000000000000000bc",RemoteTemperatureMode.RemoteTemp, 27),
-        ("fc41013010070110c70000000000000000000000009f",RemoteTemperatureMode.RemoteTemp, 35.5),
+        ("fc4101301007000f81000000000000000000000000e7", RemoteTemperatureMode.UseInternal, 0.5),
+        ("fc4101301007000aaa000000000000000000000000c3", RemoteTemperatureMode.UseInternal, 21),
+        ("fc41013010070104b6000000000000000000000000bc", RemoteTemperatureMode.RemoteTemp, 27),
+        ("fc41013010070110c70000000000000000000000009f", RemoteTemperatureMode.RemoteTemp, 35.5),
     ],
 )
-
 def test_remote_temperature_states(data_hex, mode, temperature):
     command = RemoteTemperatureStates.generate_remote_temperature_command(mode, temperature)
     assert command.hex() == data_hex


### PR DESCRIPTION
I got excited when reading about the possibility of using a remote thermostat in #16, possibly through Home Assistant, and thought I'd give it a go. I tried to understand the 0x07 command and implement it according to this [reference](https://muart-group.github.io/developer/it-protocol/0x41-set-request/0x07-set-remote-temperature). I then tested it on my MSZ-LN35VG2V which did accept the values I sent it as the new room temperature.

I did not find a way to check if the unit is using a remote thermostat or not (`RemoteTemperatureMode.UseInternal` vs `RemoteTemperatureMode.RemoteTemp`). The unit will stay in the mode you set it to. I tried setting it to `RemoteTemp` and not touching anything for some time and it did not reset back to `UseInternal`. I have not tried to turn if off and back on or power cycle the unit.

I do not have access the real thermostat hardware so I don't have any means of capturing commands from it, therefore no way of comparing this implementation to the real thing.