### PR TITLE
Add air-to-water (Ecodan / FTC) heat-pump support

### DIFF
--- a/pymitsubishi/__init__.py
+++ b/pymitsubishi/__init__.py
@@ -9,6 +9,14 @@ __version__ = "0.5.1"
 
 # Import main classes for easy access
 from .mitsubishi_api import MitsubishiAPI
+from .mitsubishi_atw import (
+    EcodanOperationMode,
+    EcodanStatus,
+    FTCVersion,
+    ZoneMode,
+    is_atw_payload,
+    parse_atw_code_values,
+)
 from .mitsubishi_controller import MitsubishiController
 from .mitsubishi_parser import (
     AutoMode,
@@ -44,4 +52,11 @@ __all__ = [
     "ParsedDeviceState",
     "RemoteLock",
     "SetRemoteTemperature",
+    # Air-to-water (Ecodan) public API
+    "EcodanStatus",
+    "EcodanOperationMode",
+    "ZoneMode",
+    "FTCVersion",
+    "is_atw_payload",
+    "parse_atw_code_values",
 ]

--- a/pymitsubishi/mitsubishi_atw.py
+++ b/pymitsubishi/mitsubishi_atw.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Mitsubishi Ecodan air-to-WATER (ATW) protocol parser & command builder.
+
+Counterpart to ``mitsubishi_parser.py`` (air-to-air). ATW units share the same
+MAC-577IF /smart transport, AES key and 0xfc framing, but are distinguished by
+the ``0x02 0x7a`` preamble (ATA uses ``0x01 0x30``) and carry a different set of
+"group" payloads (the FTC / CN105 protocol).
+
+Field decoding follows the community Ecodan CN105 maps (F1p / m000c400) and has
+been verified live against an FTC6 + PUZ-WM112 over the MELCloud adapter's local
+/smart API. Command framing (SET 0x32) is verified — the generated cool-flow
+packet is byte-identical to one accepted by the unit.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+
+from .mitsubishi_parser import calc_fcc
+
+logger = logging.getLogger(__name__)
+
+ATW_PREAMBLE = b"\x02\x7a"
+SET_REQUEST = 0x41
+
+
+class EcodanOperationMode(enum.Enum):
+    OFF = 0
+    HOT_WATER = 1
+    HEATING = 2
+    COOLING = 3
+    FROST_PROTECT = 5
+    LEGIONELLA = 6
+    HEATING_ECO = 7
+
+
+class ZoneMode(enum.Enum):
+    HEAT_TARGET = 0
+    HEAT_FLOW = 1
+    HEAT_COMPENSATION = 2
+    COOL_TARGET = 3
+    COOL_FLOW = 4
+    DRY_UP = 5
+    COOL_COMPENSATION = 6
+
+
+class FTCVersion(enum.Enum):
+    FTC2B = 0
+    FTC4 = 1
+    FTC5 = 2
+    FTC6 = 3
+    FTC7 = 5
+
+
+# --- SET 0x32 (Set Options) flags ---------------------------------------------
+SET_SYSTEM_POWER = 0x0001
+SET_HOT_WATER_MODE = 0x0004
+SET_HEATING_MODE_Z1 = 0x0008
+SET_HEATING_MODE_Z2 = 0x0010
+SET_HOT_WATER_SETPOINT = 0x0020
+SET_ZONE1_SETPOINT = 0x0080
+SET_ZONE2_SETPOINT = 0x0200
+
+
+def _enum(enum_cls, value):
+    try:
+        return enum_cls(value)
+    except ValueError:
+        return value
+
+
+def _u16(p, i):
+    return (p[i] << 8) | p[i + 1]
+
+
+def _s16(p, i):
+    v = _u16(p, i)
+    return v - 0x10000 if v >= 0x8000 else v
+
+
+def _t100(p, i):
+    return _u16(p, i) / 100.0
+
+
+def _s100(p, i):
+    return _s16(p, i) / 100.0
+
+
+def _energy(p, i):
+    return _u16(p, i) + p[i + 2] / 100.0
+
+
+@dataclasses.dataclass
+class EcodanStatus:
+    """Complete parsed Ecodan (air-to-water) state."""
+
+    # identity / capability
+    ftc_version: FTCVersion | int | None = None
+    ftc_software: str = ""
+    has_cooling: bool | None = None
+    # operation
+    power_on: bool | None = None
+    operation_mode: EcodanOperationMode | int | None = None
+    zone1_mode: ZoneMode | int | None = None
+    zone2_mode: ZoneMode | int | None = None
+    dhw_eco: bool | None = None
+    heat_cool: str | None = None
+    defrost: int | None = None
+    dhw_active: bool | None = None
+    # temperatures
+    flow_temperature: float | None = None
+    return_temperature: float | None = None
+    delta_t: float | None = None
+    outdoor_temperature: float | None = None
+    zone1_room_temperature: float | None = None
+    zone2_room_temperature: float | None = None
+    dhw_tank_temperature: float | None = None
+    mixing_tank_temperature: float | None = None
+    condensing_temperature: float | None = None
+    refrigerant_temperature: float | None = None
+    # setpoints
+    zone1_flow_setpoint: float | None = None
+    zone2_flow_setpoint: float | None = None
+    dhw_setpoint: float | None = None
+    legionella_setpoint: float | None = None
+    flow_temp_min: float | None = None
+    flow_temp_max: float | None = None
+    # plant
+    compressor_frequency: int | None = None
+    compressor_running: bool | None = None
+    run_hours: int | None = None
+    input_power_kw: int | None = None
+    output_power_kw: int | None = None
+    primary_flow_rate_lmin: int | None = None
+    primary_pump: bool | None = None
+    booster_heater: bool | None = None
+    immersion_heater: bool | None = None
+    # prohibits / flags
+    forced_dhw: bool | None = None
+    holiday_mode: bool | None = None
+    prohibit_dhw: bool | None = None
+    prohibit_heating_zone1: bool | None = None
+    prohibit_cooling_zone1: bool | None = None
+    prohibit_heating_zone2: bool | None = None
+    prohibit_cooling_zone2: bool | None = None
+    server_control_mode: bool | None = None
+    # demand
+    zone1_demand: int | None = None
+    zone2_demand: int | None = None
+    # energy (today's running totals, kWh)
+    consumed_heating_kwh: float | None = None
+    consumed_cooling_kwh: float | None = None
+    consumed_dhw_kwh: float | None = None
+    delivered_heating_kwh: float | None = None
+    delivered_cooling_kwh: float | None = None
+    delivered_dhw_kwh: float | None = None
+    # transport identity (from /smart wrapper)
+    mac: str = ""
+    serial: str = ""
+    rssi: str = ""
+
+    @property
+    def cop_today(self) -> float | None:
+        cons = sum(v for v in (self.consumed_heating_kwh, self.consumed_cooling_kwh, self.consumed_dhw_kwh) if v)
+        deliv = sum(v for v in (self.delivered_heating_kwh, self.delivered_cooling_kwh, self.delivered_dhw_kwh) if v)
+        return round(deliv / cons, 2) if cons else None
+
+
+def is_atw_payload(data: bytes) -> bool:
+    """True if a 0xfc-framed packet is an ATW (Ecodan) get-response."""
+    return len(data) >= 6 and data[1] in (0x62, 0x7B) and data[2:4] == ATW_PREAMBLE
+
+
+def parse_atw_code_values(code_values: list[str], profile_code: str | None = None) -> EcodanStatus:
+    """Parse the CODE/VALUE groups from a /smart status response into EcodanStatus."""
+    st = EcodanStatus()
+    for hexv in code_values:
+        try:
+            data = bytes.fromhex(hexv)
+            if not is_atw_payload(data):
+                continue
+            if calc_fcc(data[1:-1]) != data[-1]:
+                logger.warning("ATW checksum mismatch, ignoring: %s", hexv)
+                continue
+            _parse_group(data, st)
+        except (ValueError, IndexError) as e:
+            logger.warning("Failed to parse ATW code value %s: %s", hexv, e)
+    if profile_code:
+        try:
+            _parse_profile(bytes.fromhex(profile_code), st)
+        except (ValueError, IndexError) as e:
+            logger.warning("Failed to parse ATW profile code: %s", e)
+    return st
+
+
+def _parse_group(data: bytes, st: EcodanStatus) -> None:
+    p = data[5:21]  # group byte + 15 data bytes (== F1p "Buffer")
+    g = p[0]
+    if g == 0x01:
+        st.ftc_software = f"{p[7]:02X}.{p[8]:02X}"
+    elif g == 0x02:
+        st.defrost = p[3]
+    elif g == 0x04:
+        st.compressor_frequency = p[1]
+    elif g == 0x05:
+        st.dhw_active = bool(p[7])
+    elif g == 0x07:
+        st.input_power_kw = p[4]
+        st.output_power_kw = p[6]
+    elif g == 0x09:
+        st.zone1_flow_setpoint = _t100(p, 5)
+        st.zone2_flow_setpoint = _t100(p, 7)
+        st.legionella_setpoint = _t100(p, 9)
+        st.flow_temp_max = (p[12] - 40) / 2
+        st.flow_temp_min = (p[13] - 40) / 2
+    elif g == 0x0B:
+        st.zone1_room_temperature = _t100(p, 1) if p[1] != 0xF0 else None
+        st.zone2_room_temperature = _t100(p, 3) if p[3] != 0xF0 else None
+        st.refrigerant_temperature = _s100(p, 8)
+        st.outdoor_temperature = p[11] / 2 - 40.0
+    elif g == 0x0C:
+        flow = _t100(p, 1)
+        ret = _t100(p, 4)
+        st.flow_temperature = flow
+        st.return_temperature = ret
+        st.delta_t = round(flow - ret, 2)
+        st.dhw_tank_temperature = _t100(p, 7)
+    elif g == 0x0F:
+        st.mixing_tank_temperature = _t100(p, 1)
+        st.condensing_temperature = _s100(p, 4)
+    elif g == 0x10:
+        st.zone1_demand = p[1]
+        st.zone2_demand = p[2]
+    elif g == 0x11:
+        st.has_cooling = bool(p[3] & 0x08)  # SW2-4
+    elif g == 0x13:
+        st.compressor_running = bool(p[1])
+        st.run_hours = (p[4] << 8 | p[5]) * 100 + p[3]
+    elif g == 0x14:
+        st.booster_heater = bool(p[2] or p[3])
+        st.immersion_heater = bool(p[5])
+        st.primary_flow_rate_lmin = p[12]
+    elif g == 0x15:
+        st.primary_pump = bool(p[1])
+    elif g == 0x26:
+        st.power_on = p[3] == 1
+        st.operation_mode = _enum(EcodanOperationMode, p[4])
+        st.dhw_eco = p[5] == 1
+        st.zone1_mode = _enum(ZoneMode, p[6])
+        st.zone2_mode = _enum(ZoneMode, p[7])
+        st.dhw_setpoint = _t100(p, 8)
+    elif g == 0x28:
+        st.forced_dhw = bool(p[3])
+        st.holiday_mode = bool(p[4])
+        st.prohibit_dhw = bool(p[5])
+        st.prohibit_heating_zone1 = bool(p[6])
+        st.prohibit_cooling_zone1 = bool(p[7])
+        st.prohibit_heating_zone2 = bool(p[8])
+        st.prohibit_cooling_zone2 = bool(p[9])
+        st.server_control_mode = bool(p[10])
+    elif g == 0x29:
+        st.heat_cool = "Cool" if p[3] == 1 else "Heat"
+    elif g == 0xA1:
+        st.consumed_heating_kwh = _energy(p, 4)
+        st.consumed_cooling_kwh = _energy(p, 7)
+        st.consumed_dhw_kwh = _energy(p, 10)
+    elif g == 0xA2:
+        st.delivered_heating_kwh = _energy(p, 4)
+        st.delivered_cooling_kwh = _energy(p, 7)
+        st.delivered_dhw_kwh = _energy(p, 10)
+
+
+def _parse_profile(data: bytes, st: EcodanStatus) -> None:
+    """0xC9 extended-connect response: FTC version / refrigerant type."""
+    if len(data) < 12 or data[2:4] != ATW_PREAMBLE:
+        return
+    p = data[5:21]
+    if p[0] == 0xC9:
+        st.ftc_version = _enum(FTCVersion, p[6])
+
+
+# --- command construction -----------------------------------------------------
+def _atw_set_packet(payload: bytes) -> bytes:
+    """Frame a 16-byte SET payload (payload[0]=sub-command) into a full packet."""
+    if len(payload) != 16:
+        raise ValueError("ATW SET payload must be 16 bytes")
+    body = bytes([SET_REQUEST]) + ATW_PREAMBLE + b"\x10" + payload
+    return b"\xfc" + body + bytes([calc_fcc(body)])
+
+
+def generate_set_flow_setpoint_command(
+    zone1_setpoint: float,
+    zone2_setpoint: float,
+    dhw_setpoint: float,
+    *,
+    power_on: bool = True,
+    dhw_eco: bool = True,
+    zone_mode: ZoneMode | int = ZoneMode.COOL_FLOW,
+) -> bytes:
+    """SET 0x32 — change ONLY the Z1/Z2 flow setpoints (flags 0x80|0x02).
+
+    All other bytes carry the unit's CURRENT values so nothing else moves even if
+    the FTC acts on an unflagged field. DHW setpoint MUST be the current value
+    (anti-zero). VERIFIED on FTC6: matches a packet the unit accepted.
+    """
+    z1 = int(round(zone1_setpoint * 100))
+    z2 = int(round(zone2_setpoint * 100))
+    d = int(round(dhw_setpoint * 100))
+    m = zone_mode.value if isinstance(zone_mode, ZoneMode) else zone_mode
+    payload = bytes(
+        [
+            0x32,
+            0x80,
+            0x02,
+            1 if power_on else 0,
+            0x00,
+            1 if dhw_eco else 0,
+            m,
+            m,
+            (d >> 8) & 0xFF,
+            d & 0xFF,
+            (z1 >> 8) & 0xFF,
+            z1 & 0xFF,
+            (z2 >> 8) & 0xFF,
+            z2 & 0xFF,
+            0,
+            0,
+        ]
+    )
+    return _atw_set_packet(payload)
+
+
+def generate_set_dhw_setpoint_command(dhw_setpoint: float) -> bytes:
+    """SET 0x32 — hot-water tank setpoint (flag 0x20). Spec-derived (untested)."""
+    d = int(round(dhw_setpoint * 100))
+    flags = SET_HOT_WATER_SETPOINT
+    payload = bytes(
+        [0x32, flags & 0xFF, (flags >> 8) & 0xFF, 0, 0, 0, 0, 0, (d >> 8) & 0xFF, d & 0xFF, 0, 0, 0, 0, 0, 0]
+    )
+    return _atw_set_packet(payload)
+
+
+def generate_set_zone_mode_command(zone1_mode: ZoneMode | int, zone2_mode: ZoneMode | int) -> bytes:
+    """SET 0x32 — heating/cooling control mode per zone (flags 0x08|0x10). Spec-derived (untested)."""
+    m1 = zone1_mode.value if isinstance(zone1_mode, ZoneMode) else zone1_mode
+    m2 = zone2_mode.value if isinstance(zone2_mode, ZoneMode) else zone2_mode
+    flags = SET_HEATING_MODE_Z1 | SET_HEATING_MODE_Z2
+    payload = bytes([0x32, flags & 0xFF, (flags >> 8) & 0xFF, 0, 0, 0, m1, m2, 0, 0, 0, 0, 0, 0, 0, 0])
+    return _atw_set_packet(payload)
+
+
+def generate_set_power_command(power_on: bool) -> bytes:
+    """SET 0x32 — system power (flag 0x01). Spec-derived (untested)."""
+    payload = bytes([0x32, SET_SYSTEM_POWER, 0, 1 if power_on else 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    return _atw_set_packet(payload)
+
+
+def generate_forced_dhw_command(on: bool) -> bytes:
+    """SET 0x34 — force DHW (boost). Flag 0x01, byte[3]. Spec-derived (untested)."""
+    payload = bytes([0x34, 0x01, 0, 1 if on else 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    return _atw_set_packet(payload)

--- a/pymitsubishi/mitsubishi_controller.py
+++ b/pymitsubishi/mitsubishi_controller.py
@@ -11,6 +11,17 @@ from typing import Any
 import xml.etree.ElementTree as ET
 
 from .mitsubishi_api import MitsubishiAPI
+from .mitsubishi_atw import (
+    EcodanStatus,
+    ZoneMode,
+    generate_forced_dhw_command,
+    generate_set_dhw_setpoint_command,
+    generate_set_flow_setpoint_command,
+    generate_set_power_command,
+    generate_set_zone_mode_command,
+    is_atw_payload,
+    parse_atw_code_values,
+)
 from .mitsubishi_parser import (
     Controls,
     Controls08,
@@ -87,6 +98,11 @@ class MitsubishiController:
         self.profile_code: list[bytes] = []
         self.state: ParsedDeviceState | None = None
         self.unit_info: dict[str, dict[str, Any]] = {}
+        # Air-to-water (Ecodan) support. Populated automatically by
+        # _parse_status_response when the device responds with ATW payloads.
+        self.is_atw: bool = False
+        self.atw_status: EcodanStatus | None = None
+        self.has_zone2: bool = False
 
     @classmethod
     def create(cls, device_host_port: str, encryption_key: str | bytes = "unregistered"):
@@ -122,11 +138,68 @@ class MitsubishiController:
 
         profile_elems = root.findall(".//PROFILECODE/DATA/VALUE") or root.findall(".//PROFILECODE/VALUE")
         self.profile_code = []
+        profile_hex: list[str] = []
         for elem in profile_elems:
             if elem.text:
+                profile_hex.append(elem.text)
                 self.profile_code.append(bytes.fromhex(elem.text))
 
+        # Detect and parse an air-to-water (Ecodan) unit. ATW status packets use
+        # a different preamble (0x02 0x7a) so they are ignored by the ATA parser
+        # above and recognised here. This is purely additive: air-to-air devices
+        # never pass is_atw_payload, so their behaviour is unchanged.
+        self._parse_atw_status(code_values, profile_hex, root)
+
         return self.state
+
+    def _parse_atw_status(self, code_values: list[str], profile_hex: list[str], root: ET.Element) -> None:
+        """Detect ATW (Ecodan) payloads and populate is_atw / atw_status / has_zone2."""
+        is_atw = False
+        for hexv in code_values:
+            try:
+                if is_atw_payload(bytes.fromhex(hexv)):
+                    is_atw = True
+                    break
+            except ValueError:
+                continue
+
+        self.is_atw = is_atw
+        if not is_atw:
+            self.atw_status = None
+            self.has_zone2 = False
+            return
+
+        # The profile code carries FTC version / refrigerant type (0xC9 group).
+        # Pick the ATW profile packet so parse_atw_code_values can decode it.
+        atw_profile: str | None = None
+        for hexv in profile_hex:
+            try:
+                data = bytes.fromhex(hexv)
+            except ValueError:
+                continue
+            if len(data) >= 6 and data[2:4] == b"\x02\x7a" and data[5] == 0xC9:
+                atw_profile = hexv
+                break
+
+        status = parse_atw_code_values(code_values, atw_profile)
+
+        # Identity from the /smart XML wrapper.
+        mac_elem = root.find(".//MAC")
+        if mac_elem is not None and mac_elem.text is not None:
+            status.mac = mac_elem.text
+        serial_elem = root.find(".//SERIAL")
+        if serial_elem is not None and serial_elem.text is not None:
+            status.serial = serial_elem.text
+        rssi_elem = root.find(".//RSSI")
+        if rssi_elem is not None and rssi_elem.text is not None:
+            status.rssi = rssi_elem.text
+
+        self.atw_status = status
+        self.has_zone2 = (
+            status.zone2_room_temperature is not None
+            or status.zone2_flow_setpoint is not None
+            or status.zone2_mode is not None
+        )
 
     def _ensure_state_available(self):
         if self.state is None or self.state.general is None:
@@ -174,11 +247,6 @@ class MitsubishiController:
             ),
             remote_lock=overrides.get("remote_lock", self.state.general.remote_lock),
         )
-
-    def set_power(self, power_on: bool) -> ParsedDeviceState | None:
-        cs = self.changeset()
-        cs.set_power(PowerOnOff.ON if power_on else PowerOnOff.OFF)
-        return self.apply_changeset(cs)
 
     def set_temperature(self, temperature_celsius: float) -> ParsedDeviceState | None:
         cs = self.changeset()
@@ -244,6 +312,85 @@ class MitsubishiController:
         new_state = self._send_general_control_command(updated_state, Controls.RemoteLock)
         self.state = new_state
         return new_state
+
+    # --- Air-to-water (Ecodan) control --------------------------------------
+    # Each builds a packet via mitsubishi_atw and sends it via the shared
+    # transport. They return True on success and deliberately do NOT re-fetch
+    # status; the caller should call fetch_status() after a settle delay.
+
+    def _require_atw_status(self) -> EcodanStatus:
+        if self.atw_status is None:
+            self.fetch_status()
+        if not self.is_atw or self.atw_status is None:
+            raise RuntimeError("Not an air-to-water device or status unavailable")
+        return self.atw_status
+
+    def _send_atw_command(self, command: bytes) -> bool:
+        """Send a prebuilt ATW packet; return True if the device accepted it."""
+        try:
+            self.api.send_command(command)
+            return True
+        except Exception:
+            logger.exception("Failed to send ATW command")
+            return False
+
+    def set_zone_flow_setpoint(
+        self,
+        zone1_setpoint: float,
+        zone2_setpoint: float,
+        zone_mode: ZoneMode | None = None,
+    ) -> bool:
+        """Set the Z1/Z2 flow setpoints, preserving DHW/power/eco state.
+
+        If zone_mode is None the unit's current Zone-1 mode is reused.
+        """
+        status = self._require_atw_status()
+        mode: ZoneMode | int
+        if zone_mode is not None:
+            mode = zone_mode
+        elif status.zone1_mode is not None:
+            mode = status.zone1_mode
+        else:
+            mode = ZoneMode.COOL_FLOW
+        dhw_setpoint = status.dhw_setpoint if status.dhw_setpoint is not None else 50.0
+        power_on = status.power_on if status.power_on is not None else True
+        dhw_eco = status.dhw_eco if status.dhw_eco is not None else True
+        command = generate_set_flow_setpoint_command(
+            zone1_setpoint,
+            zone2_setpoint,
+            dhw_setpoint,
+            power_on=power_on,
+            dhw_eco=dhw_eco,
+            zone_mode=mode,
+        )
+        return self._send_atw_command(command)
+
+    def set_dhw_setpoint(self, temp: float) -> bool:
+        """Set the hot-water tank target temperature."""
+        return self._send_atw_command(generate_set_dhw_setpoint_command(temp))
+
+    def set_dhw_boost(self, on: bool) -> bool:
+        """Force (boost) hot-water production on or off."""
+        return self._send_atw_command(generate_forced_dhw_command(on))
+
+    def set_zone_mode(self, zone1: ZoneMode, zone2: ZoneMode) -> bool:
+        """Set the heating/cooling control mode for each zone."""
+        return self._send_atw_command(generate_set_zone_mode_command(zone1, zone2))
+
+    def set_power(self, on: bool) -> bool | ParsedDeviceState | None:
+        """Turn the system on or off.
+
+        On an air-to-water (Ecodan) unit this sends the ATW power packet and
+        returns True/False for success (the documented ATW contract). On an
+        air-to-air unit it preserves the original changeset behaviour and
+        returns the updated ParsedDeviceState.
+        """
+        if self.is_atw:
+            return self._send_atw_command(generate_set_power_command(on))
+        # Air-to-air power control (original behaviour, unchanged).
+        cs = self.changeset()
+        cs.set_power(PowerOnOff.ON if on else PowerOnOff.OFF)
+        return self.apply_changeset(cs)
 
     def _send_general_control_command(self, state: GeneralStates, controls: Controls) -> ParsedDeviceState:
         """Send a general control command to the device"""

--- a/tests/test_atw.py
+++ b/tests/test_atw.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for the air-to-WATER (Mitsubishi Ecodan) protocol codec in
+``pymitsubishi.mitsubishi_atw``.
+
+All packets used here are REAL captures verified live against an FTC6 + PUZ-WM112
+over the MELCloud adapter's local /smart API. No network access is performed.
+
+Importing the full ``pymitsubishi`` package pulls in ``mitsubishi_api`` which
+requires ``requests`` and ``pycryptodome`` (``Crypto``). ``mitsubishi_atw`` itself
+only needs ``calc_fcc`` from the stdlib-only ``mitsubishi_parser``. To keep these
+tests runnable with ``python3 -m pytest`` whether or not those heavy deps are
+installed, we import the package normally when possible and otherwise load the two
+modules directly via importlib, registering a stub ``pymitsubishi`` package in
+``sys.modules`` so the ``from .mitsubishi_parser import calc_fcc`` relative import
+inside ``mitsubishi_atw`` still resolves.
+"""
+
+import importlib
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+# pymitsubishi/pymitsubishi/  (the inner package dir holding the modules)
+_PKG_DIR = pathlib.Path(__file__).resolve().parent.parent / "pymitsubishi"
+
+
+def _load_atw_module():
+    """Return the mitsubishi_atw module, avoiding the package __init__ if its
+    optional heavy dependencies (requests / pycryptodome) are unavailable."""
+    # Fast path: real package import (works when deps are present).
+    try:
+        return importlib.import_module("pymitsubishi.mitsubishi_atw")
+    except Exception:  # pragma: no cover - depends on the test environment
+        pass
+
+    # Fallback: register a stub package and exec the two stdlib-only modules
+    # directly, bypassing pymitsubishi/__init__.py (which imports Crypto).
+    if "pymitsubishi" not in sys.modules or not getattr(sys.modules["pymitsubishi"], "__path__", None):
+        stub = types.ModuleType("pymitsubishi")
+        stub.__path__ = [str(_PKG_DIR)]
+        sys.modules["pymitsubishi"] = stub
+
+    def _exec(name):
+        full = f"pymitsubishi.{name}"
+        spec = importlib.util.spec_from_file_location(full, _PKG_DIR / f"{name}.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[full] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _exec("mitsubishi_parser")  # provides calc_fcc for the relative import
+    return _exec("mitsubishi_atw")
+
+
+atw = _load_atw_module()
+
+EcodanStatus = atw.EcodanStatus
+EcodanOperationMode = atw.EcodanOperationMode
+ZoneMode = atw.ZoneMode
+FTCVersion = atw.FTCVersion
+is_atw_payload = atw.is_atw_payload
+parse_atw_code_values = atw.parse_atw_code_values
+generate_set_flow_setpoint_command = atw.generate_set_flow_setpoint_command
+
+
+# --- Real captured packets (FTC6 + PUZ-WM112) ---------------------------------
+CODE_SETPOINTS = "fc62027a100907d007d007080708177032965000009e"  # group 0x09
+CODE_TEMPS_ROOM = "fc62027a100b0a280a28f0c40b09c40b7e000000008e"  # group 0x0B
+CODE_TEMPS_FLOW = "fc62027a100c079e700802731162a909c40b00000080"  # group 0x0C
+CODE_OPERATION = "fc62027a10260000000001040413880708070800002a"  # group 0x26
+PROFILE_CODE = "fc7b027a10c903000100140300010100000000000013"  # 0xC9 profile
+
+ALL_CODES = [CODE_SETPOINTS, CODE_TEMPS_ROOM, CODE_TEMPS_FLOW, CODE_OPERATION]
+
+# An ATA (air-to-air) style packet: preamble 01 30, not 02 7a.
+ATA_PACKET_HEX = "fc6201301002000000000000000000000000000000"
+
+
+@pytest.fixture(scope="module")
+def status() -> EcodanStatus:
+    """Parse the full set of captured codes + profile once for the module."""
+    return parse_atw_code_values(ALL_CODES, profile_code=PROFILE_CODE)
+
+
+# --- Test 1: parse_atw_code_values decodes the real packets -------------------
+class TestParseAtwCodeValues:
+    def test_returns_ecodan_status(self, status):
+        assert isinstance(status, EcodanStatus)
+
+    def test_flow_setpoints_and_limits(self, status):
+        assert status.zone1_flow_setpoint == 18.0
+        assert status.zone2_flow_setpoint == 18.0
+        assert status.legionella_setpoint == 60.0
+        assert status.flow_temp_min == 20.0
+        assert status.flow_temp_max == 55.0
+
+    def test_room_and_outdoor_temperatures(self, status):
+        assert status.zone1_room_temperature == 26.0
+        assert status.zone2_room_temperature == 26.0
+        assert status.outdoor_temperature == 23.0
+
+    def test_flow_return_delta_and_dhw_tank(self, status):
+        assert status.flow_temperature == 19.5
+        assert status.return_temperature == 20.5
+        assert status.delta_t == -1.0
+        assert status.dhw_tank_temperature == 44.5
+
+    def test_operation_group(self, status):
+        assert status.power_on is False
+        assert status.operation_mode == EcodanOperationMode.OFF
+        assert status.dhw_eco is True
+        assert status.zone1_mode == ZoneMode.COOL_FLOW
+        assert status.zone2_mode == ZoneMode.COOL_FLOW
+        assert status.dhw_setpoint == 50.0
+
+    def test_profile_ftc_version(self, status):
+        assert status.ftc_version == FTCVersion.FTC6
+
+    def test_order_independent(self):
+        """Decoding must not depend on the order codes arrive in."""
+        st = parse_atw_code_values(list(reversed(ALL_CODES)), profile_code=PROFILE_CODE)
+        assert st.zone1_flow_setpoint == 18.0
+        assert st.operation_mode == EcodanOperationMode.OFF
+        assert st.ftc_version == FTCVersion.FTC6
+
+    def test_profile_optional(self):
+        """Without a profile code, ftc_version stays unset; other fields parse."""
+        st = parse_atw_code_values(ALL_CODES)
+        assert st.ftc_version is None
+        assert st.flow_temperature == 19.5
+
+
+# --- Test 2: is_atw_payload distinguishes ATW from ATA ------------------------
+class TestIsAtwPayload:
+    def test_atw_packet_is_true(self):
+        assert is_atw_payload(bytes.fromhex(CODE_TEMPS_FLOW)) is True
+
+    def test_ata_packet_is_false(self):
+        assert is_atw_payload(bytes.fromhex(ATA_PACKET_HEX)) is False
+
+    def test_too_short_is_false(self):
+        assert is_atw_payload(b"\xfc\x62") is False
+
+
+# --- Test 3: command builder is byte-exact ------------------------------------
+class TestGenerateSetFlowSetpointCommand:
+    def test_byte_exact_cool_flow(self):
+        cmd = generate_set_flow_setpoint_command(19.0, 19.0, 50.0, zone_mode=ZoneMode.COOL_FLOW)
+        assert cmd.hex() == "fc41027a1032800201000104041388076c076c0000f4"
+
+    def test_returns_22_byte_packet(self):
+        cmd = generate_set_flow_setpoint_command(19.0, 19.0, 50.0)
+        assert isinstance(cmd, bytes | bytearray)
+        assert len(cmd) == 22
+        # 0xfc framing + ATW 0x41 02 7a 10 header
+        assert cmd[0] == 0xFC
+        assert cmd[1] == 0x41
+        assert cmd[2:4] == atw.ATW_PREAMBLE
+
+
+# --- Test 4: checksum / round-trip invariant for every command builder --------
+def _all_generated_commands():
+    """Exercise every public command builder with representative arguments."""
+    cmds = [
+        atw.generate_set_flow_setpoint_command(19.0, 19.0, 50.0),
+        atw.generate_set_flow_setpoint_command(
+            18.5, 21.0, 48.0, power_on=False, dhw_eco=False, zone_mode=ZoneMode.HEAT_FLOW
+        ),
+        atw.generate_set_flow_setpoint_command(20.0, 20.0, 50.0, zone_mode=4),
+        atw.generate_set_dhw_setpoint_command(50.0),
+        atw.generate_set_zone_mode_command(ZoneMode.HEAT_FLOW, ZoneMode.COOL_FLOW),
+        atw.generate_set_zone_mode_command(1, 4),
+        atw.generate_set_power_command(True),
+        atw.generate_set_power_command(False),
+        atw.generate_forced_dhw_command(True),
+        atw.generate_forced_dhw_command(False),
+    ]
+    return cmds
+
+
+@pytest.mark.parametrize("cmd", _all_generated_commands())
+def test_command_checksum_invariant(cmd):
+    """Last byte must be the Mitsubishi FCC over bytes[1:-1]."""
+    expected = (0x100 - sum(cmd[1:-1]) % 0x100) % 0x100
+    assert cmd[-1] == expected
+
+
+@pytest.mark.parametrize("cmd", _all_generated_commands())
+def test_command_well_formed(cmd):
+    """Every builder yields a 22-byte 0xfc-framed ATW SET packet."""
+    assert len(cmd) == 22
+    assert cmd[0] == 0xFC
+    assert cmd[1] == atw.SET_REQUEST
+    assert cmd[2:4] == atw.ATW_PREAMBLE


### PR DESCRIPTION
Implements #24 — air-to-water (Ecodan / FTC heat-pump) support.

Uses the **same** `/smart` transport as air-con; ATW is distinguished by the `0x02 0x7a` preamble (ATA uses `0x01 0x30`) and the FTC/CN105 "group" payloads.

- `mitsubishi_atw.py` — `EcodanStatus` parser + SET command builders, a sibling to `mitsubishi_parser.py`.
- `mitsubishi_controller.py` — auto-detects ATA vs ATW on fetch; exposes `atw_status` + `set_zone_flow_setpoint` / `set_dhw_setpoint` / `set_dhw_boost` / `set_zone_mode` / `set_power`. **The air-to-air path is unchanged.**
- `__init__.py` — exports the ATW public API.
- `tests/test_atw.py` — 33 tests.

### Verification
- Full suite green (**162 passed**), including the new ATW tests.
- Decode verified against captured packets and **live on an FTC6 + PUZ-WM112** via the MAC-577IF `/smart` API; the generated cool-flow SET packet is **byte-identical** to one the unit accepted.

### Caveats
- Tested on **FTC6** only so far (FTC4/5/7 have hooks but are unverified).
- Static `unregistered` AES key (works on this cloud-registered adapter).
- A matching `homeassistant-mitsubishi` PR (water_heater + per-zone climate + sensors) will follow.

Glad to reshape (e.g. a separate ATW controller) to fit the project's direction.
